### PR TITLE
Added the key ping subcommands for the key queue

### DIFF
--- a/app.js
+++ b/app.js
@@ -1267,6 +1267,21 @@ keyqueueCommand.registerSubcommand("toggle", keyqueue.toggleKeyQueue, {
     description: `Toggles the key queue on/off`
 });
 
+keyqueueCommand.registerSubcommand("toggleKeyPing", keyqueue.toggleKeyPing, {
+    fullDescription: keyqueue.toggleKeyPingHelpMessage,
+    description: `Toggles the key ping on/off`
+});
+
+keyqueueCommand.registerSubcommand("setPingChannel", keyqueue.setPingChannel, {
+    fullDescription: keyqueue.setPingChannelHelp,
+    description: `Sets the channel to ping in when a key is added to the queue`
+})
+
+keyqueueCommand.registerSubcommand("setPingRole", keyqueue.setPingRole, {
+    fullDescription: keyqueue.setPingRoleHelp,
+    description: `Sets the role to ping when a key is added to the queue`
+})
+
 keyqueueCommand.registerSubcommand("setup", keyqueue.setupKeyQueueMessage, {
     fullDescription: keyqueue.setupKeyQueueMessageHelpMessage,
     description: `Sets up the key queue message (with reactions).`

--- a/app.js
+++ b/app.js
@@ -1263,26 +1263,31 @@ const keyqueueCommand = CONSTANTS.bot.registerCommand("keyqueue", function(msg, 
 })
 
 keyqueueCommand.registerSubcommand("toggle", keyqueue.toggleKeyQueue, {
+    caseInsensitive: true,
     fullDescription: keyqueue.toggleKeyQueueHelpMessage,
     description: `Toggles the key queue on/off`
 });
 
 keyqueueCommand.registerSubcommand("toggleKeyPing", keyqueue.toggleKeyPing, {
+    caseInsensitive: true,
     fullDescription: keyqueue.toggleKeyPingHelpMessage,
     description: `Toggles the key ping on/off`
 });
 
 keyqueueCommand.registerSubcommand("setPingChannel", keyqueue.setPingChannel, {
+    caseInsensitive: true, 
     fullDescription: keyqueue.setPingChannelHelp,
     description: `Sets the channel to ping in when a key is added to the queue`
 })
 
 keyqueueCommand.registerSubcommand("setPingRole", keyqueue.setPingRole, {
+    caseInsensitive: true, 
     fullDescription: keyqueue.setPingRoleHelp,
     description: `Sets the role to ping when a key is added to the queue`
 })
 
 keyqueueCommand.registerSubcommand("setup", keyqueue.setupKeyQueueMessage, {
+    caseInsensitive: true, 
     fullDescription: keyqueue.setupKeyQueueMessageHelpMessage,
     description: `Sets up the key queue message (with reactions).`
 });

--- a/config/config.js
+++ b/config/config.js
@@ -191,7 +191,7 @@ exports.deleteGuildRole = function(guild, role) {
       exports.SystemConfig.servers[guild.id].keyqueue.pingrole = undefined;
       exports.SystemConfig.servers[guild.id].keyqueue.keyping = false;
 
-      CONSTANTS.bot.createMessage(exports.SystemConfig.servers[channel.guild.id].logchannel, "The key queue pinging feature has been automatically disabled as the role has been deleted.").catch({});
+      CONSTANTS.bot.createMessage(exports.SystemConfig.servers[guild.id].logchannel, "The key queue pinging feature has been automatically disabled as the role has been deleted.").catch({});
     }
 
     CONSTANTS.bot.createMessage(exports.SystemConfig.servers[guild.id].logchannel, `The ${role.name} role was deleted, and as such it has been removed from all configurations.`).catch({});

--- a/config/config.js
+++ b/config/config.js
@@ -185,6 +185,15 @@ exports.deleteGuildRole = function(guild, role) {
     exports.SystemConfig.servers[guild.id].quotaEnabledRoles = exports.SystemConfig.servers[guild.id].quotaEnabledRoles.filter(roleID => roleID != role.id);
     exports.SystemConfig.servers[guild.id].quotaOverrideRoles = exports.SystemConfig.servers[guild.id].quotaOverrideRoles.filter(roleID => roleID != role.id);
 
+    if (exports.SystemConfig.servers[guild.id].keyqueue.pingrole == role.id) {
+      // Disable the key pinging message if the key ping role has been deleted
+      
+      exports.SystemConfig.servers[guild.id].keyqueue.pingrole = undefined;
+      exports.SystemConfig.servers[guild.id].keyqueue.keyping = false;
+
+      CONSTANTS.bot.createMessage(exports.SystemConfig.servers[channel.guild.id].logchannel, "The key queue pinging feature has been automatically disabled as the role has been deleted.").catch({});
+    }
+
     CONSTANTS.bot.createMessage(exports.SystemConfig.servers[guild.id].logchannel, `The ${role.name} role was deleted, and as such it has been removed from all configurations.`).catch({});
     updateConfig(guild.id);
     return;
@@ -215,6 +224,16 @@ exports.deleteChannel = function(channel) {
       if (exports.SystemConfig.servers[channel.guild.id].channels.Veteran.ActiveRaidsChannelID == channel.id) exports.SystemConfig.servers[channel.guild.id].channels.Veteran.ActiveRaidsChannelID = undefined;
       if (exports.SystemConfig.servers[channel.guild.id].channels.Veteran.LocationChannelID == channel.id) exports.SystemConfig.servers[channel.guild.id].channels.Veteran.LocationChannelID = undefined;
       if (exports.SystemConfig.servers[channel.guild.id].channels.Veteran.EarlyReactionsLogChannelID == channel.id) exports.SystemConfig.servers[channel.guild.id].channels.Veteran.EarlyReactionsLogChannelID = undefined;
+      channelWasInConfig = true;
+    }
+    if (exports.SystemConfig.servers[channel.guild.id].keyqueue.pingchannel == channel.id) {
+      // Disable the key pinging message if the key ping channel has been deleted
+
+      exports.SystemConfig.servers[channel.guild.id].keyqueue.pingchannel = undefined;
+      exports.SystemConfig.servers[channel.guild.id].keyqueue.keyping = false;
+
+      CONSTANTS.bot.createMessage(exports.SystemConfig.servers[channel.guild.id].logchannel, "The key queue pinging feature has been automatically disabled as the channel has been deleted.").catch({});
+
       channelWasInConfig = true;
     }
     if (channelWasInConfig) {

--- a/config/keyqueue.js
+++ b/config/keyqueue.js
@@ -59,6 +59,80 @@ Toggles the automated key queue handling on/off.
 
 **Usage**: \`${CONSTANTS.botPrefix}keyqueue toggle\``
 
+async function toggleKeyPing(msg, args) {
+    if (!CONFIG.SystemConfig.servers[msg.guildID]) return "Run the `.config` command first.";
+    else if (!CONFIG.SystemConfig.servers[msg.guildID].premium) return "Error: That's a premium only service.";
+    else if (!CONFIG.SystemConfig.servers[msg.guildID].keyqueue.enabled) return "Error: The key queue needs to be enabled first. Run `.keyqueue toggle`."
+    else if (!CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingchannel) return "Error: The ping channel needs to be set first. Run `.keyqueue setPingChannel <#channel>`.";
+    else if (!CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingrole) return "Error: The ping role needs to be set first. Run `.keyqueue setPingRole <@role>`.";
+
+    CONFIG.SystemConfig.servers[msg.guildID].keyqueue.keyping = !(CONFIG.SystemConfig.servers[msg.guildID].keyqueue.keyping);
+    CONFIG.updateConfig(msg.guildID);
+
+    return `Key Ping Toggled To: \`${CONFIG.SystemConfig.servers[msg.guildID].keyqueue.keyping}\``;
+}
+
+exports.toggleKeyPing = toggleKeyPing;
+
+exports.toggleKeyPingHelpMessage = `
+**Key Queue toggleKeyPing Command**
+
+Toggles the automatic pinging when someone adds a key to the key queue.
+
+**Usage**: \`${CONSTANTS.botPrefix}keyqueue toggleKeyPing\``;
+
+async function setPingChannel(msg, args) {
+    if (!CONFIG.SystemConfig.servers[msg.guildID]) return "Run the `.config` command first.";
+    else if (!CONFIG.SystemConfig.servers[msg.guildID].premium) return "Error: That's a premium only service.";
+    else if (!CONFIG.SystemConfig.servers[msg.guildID].keyqueue.enabled) return "Error: The key queue needs to be enabled first. Run `.keyqueue toggle`."
+    else if (!(msg.channelMentions.length > 0)) return "You need to mention a channel for that!";
+    
+    let pingChannel = msg.channelMentions[0];
+    if (CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingchannel != pingChannel) CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingchannel = pingChannel;
+
+    CONFIG.updateConfig(msg.guildID);
+
+    return `Successfully set channel <#${pingChannel}> as the key ping channel.`;
+}
+
+exports.setPingChannel = setPingChannel;
+
+exports.setPingChannelHelp = `
+**Set Key Queue Ping Channel**
+
+Sets the channel for the bot to ping in when someone adds a key to the queue.
+
+**Usage**: \`${CONSTANTS.botPrefix}keyqueue setPingChannel <#channel>\`
+
+**<#channel>**: A mention of the channel you would like to set for this type. To mention a channel, do <#channelID>.
+`;
+
+async function setPingRole(msg, args) {
+    if (!CONFIG.SystemConfig.servers[msg.guildID]) return "Run the `.config` command first.";
+    else if (!CONFIG.SystemConfig.servers[msg.guildID].premium) return "Error: That's a premium only service.";
+    else if (!CONFIG.SystemConfig.servers[msg.guildID].keyqueue.enabled) return "Error: The key queue needs to be enabled first. Run `.keyqueue toggle`."
+    else if (!(msg.roleMentions.length > 0)) return "You need to mention a role for that!";
+    
+    let pingRole = msg.roleMentions[0];
+    if (CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingrole != pingRole) CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingrole = pingRole;
+
+    CONFIG.updateConfig(msg.guildID);
+
+    return `Successfully set role <@&${pingRole}> as the key ping role.`;
+}
+
+exports.setPingRole = setPingRole;
+
+exports.setPingRoleHelp = `
+**Set Key Queue Ping Role**
+
+Sets the role for the bot to ping when someone adds a key to the queue.
+
+**Usage**: \`${CONSTANTS.botPrefix}keyqueue setPingRole <@role>\`
+
+**<@role>**: A mention of the role you would like to set for this type. To mention a channel, do <@role>.
+`;
+
 async function setupKeyQueueMessage(msg, args) {
     if (!CONFIG.SystemConfig.servers[msg.guildID]) return "Run the `.config` command first.";
     else if (!CONFIG.SystemConfig.servers[msg.guildID].premium) return "Error: That's a premium only service.";
@@ -226,6 +300,13 @@ exports.keyqueueReacted = async function(msg, emoji, member) {
                                 color: 0x00ab30
                             }
                         });
+
+                        if (CONFIG.SystemConfig.servers[msg.guildID].keyqueue.keyping) {
+                            let pingChannel = await CONSTANTS.bot.getChannel(CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingchannel);
+                            let pingRole = CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingrole;
+
+                            await pingChannel.createMessage(`<@&${pingRole}> ${member.mention} has ${numItems} <:${emojiText}> to pop!`);
+                        }
                     })   
                     setTimeout(() => {
                         if (!hasMsged) {
@@ -299,6 +380,13 @@ exports.keyqueueReacted = async function(msg, emoji, member) {
                             color: 0x00ab30
                         }
                     });
+
+                    if (CONFIG.SystemConfig.servers[msg.guildID].keyqueue.keyping) {
+                        let pingChannel = await CONSTANTS.bot.getChannel(CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingchannel);
+                        let pingRole = CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingrole;
+
+                        await pingChannel.createMessage(`<@&${pingRole}> ${member.mention} has ${numItems} <:${emojiText}> to pop!`);
+                    }
                 })
                 
                 setTimeout(() => {

--- a/config/keyqueue.js
+++ b/config/keyqueue.js
@@ -88,9 +88,11 @@ async function setPingChannel(msg, args) {
     else if (!(msg.channelMentions.length > 0)) return "You need to mention a channel for that!";
     
     let pingChannel = msg.channelMentions[0];
-    if (CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingchannel != pingChannel) CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingchannel = pingChannel;
-
-    CONFIG.updateConfig(msg.guildID);
+    
+    if (CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingchannel != pingChannel) {
+        CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingchannel = pingChannel;
+        CONFIG.updateConfig(msg.guildID);
+    }
 
     return `Successfully set channel <#${pingChannel}> as the key ping channel.`;
 }
@@ -114,9 +116,11 @@ async function setPingRole(msg, args) {
     else if (!(msg.roleMentions.length > 0)) return "You need to mention a role for that!";
     
     let pingRole = msg.roleMentions[0];
-    if (CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingrole != pingRole) CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingrole = pingRole;
-
-    CONFIG.updateConfig(msg.guildID);
+    
+    if (CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingrole != pingRole) {
+        CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingrole = pingRole;
+        CONFIG.updateConfig(msg.guildID);
+    }
 
     return `Successfully set role <@&${pingRole}> as the key ping role.`;
 }
@@ -302,10 +306,17 @@ exports.keyqueueReacted = async function(msg, emoji, member) {
                         });
 
                         if (CONFIG.SystemConfig.servers[msg.guildID].keyqueue.keyping) {
-                            let pingChannel = await CONSTANTS.bot.getChannel(CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingchannel);
                             let pingRole = CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingrole;
 
-                            await pingChannel.createMessage(`<@&${pingRole}> ${member.mention} has ${numItems} <:${emojiText}> to pop!`);
+                            CONSTANTS.bot.createMessage(CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingchannel,
+                                `<@&${pingRole}> ${member.mention} has ${numItems} <:${emojiText}> to pop!`
+                            ).catch((e) => {
+                                console.log("> [ERROR SENDING KEY PING MESSAGE] " + e);
+
+                                CONSTANTS.bot.createMessage(CONFIG.SystemConfig.servers[msg.guildID].logchannel,
+                                    "Error: An error occurred while trying to send the key ping message"
+                                ).catch((e) => { console.log("> [ERROR SENDING MESSAGE TO LOG CHANNEL] " + e) });
+                            });
                         }
                     })   
                     setTimeout(() => {
@@ -382,10 +393,17 @@ exports.keyqueueReacted = async function(msg, emoji, member) {
                     });
 
                     if (CONFIG.SystemConfig.servers[msg.guildID].keyqueue.keyping) {
-                        let pingChannel = await CONSTANTS.bot.getChannel(CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingchannel);
                         let pingRole = CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingrole;
 
-                        await pingChannel.createMessage(`<@&${pingRole}> ${member.mention} has ${numItems} <:${emojiText}> to pop!`);
+                        CONSTANTS.bot.createMessage(CONFIG.SystemConfig.servers[msg.guildID].keyqueue.pingchannel, 
+                            `<@&${pingRole}> ${member.mention} has ${numItems} <:${emojiText}> to pop!`
+                        ).catch((e) => {
+                            console.log("> [ERROR SENDING KEY PING MESSAGE] " + e);
+
+                            CONSTANTS.bot.createMessage(CONFIG.SystemConfig.servers[msg.guildID].logchannel,
+                                "Error: An error occurred while trying to send the key ping message"
+                            ).catch((e) => { console.log("> [ERROR SENDING MESSAGE TO LOG CHANNEL] " + e) });
+                        });
                     }
                 })
                 

--- a/config/showconfig.js
+++ b/config/showconfig.js
@@ -43,6 +43,13 @@ function showConfigDefault(msg, args) {
             **Quota Enabled Roles**: (do \`.showconfig quotaenabledroles\` for more)
             **Quota Override Roles**: (do \`.showconfig quotaoverrideroles\` for more)
 
+            **Key Queue**:
+
+            **Key Queue Enabled**: \`${server.keyqueue.enabled}\`
+            **Key Queue Ping Enabled**: \`${server.keyqueue.keyping}\`
+            **Key Queue Ping Channel**: <#${server.keyqueue.pingchannel}>
+            **Key Queue Ping Role**: <@&${server.keyqueue.pingrole}>
+
             **Auto Key Popper Role Configuration**: (do \`.showconfig keyroles\` for more)
             `,
             color: 3145463


### PR DESCRIPTION
Hi,

I have implemented the key ping subcommands. Server administrators can now configure the bot to automatically ping a role when a key is added the the key queue. 

**This is configured as follows:** 
First you set the channel to ping in with this command `.kq setPingChannel <#channel>` 
Then you set the role to be pinged with `.kq setPingRole <@role>`
Finally you can enable the feature with `.kq toggleKeyPing`.

The feature can be disabled/re-enabled easily by running the `.kq toggleKeyPing` command.

Any feedback is appreciated, thanks 😄 