### PR TITLE
Daily claim

### DIFF
--- a/app.js
+++ b/app.js
@@ -1328,7 +1328,7 @@ const STDCreditsCommand = CONSTANTS.bot.registerCommand("credits", STD_gamble.cr
 
 CONSTANTS.bot.registerCommand("claim", STD_gamble.claim, {
     caseInsensitive: true,
-    fullDescription: "Claim your 10 daily credits!",
+    fullDescription: "Claim your 10 daily credits!\nClaim every day to get a streak and earn an extra credit per day in your streak (max of 5 extra credits)",
     argsRequired: false,
     requirements: {
         custom: function(msg) {

--- a/app.js
+++ b/app.js
@@ -1326,6 +1326,20 @@ const STDCreditsCommand = CONSTANTS.bot.registerCommand("credits", STD_gamble.cr
     }
 });
 
+CONSTANTS.bot.registerCommand("claim", STD_gamble.claim, {
+    caseInsensitive: true,
+    fullDescription: "Claim your 10 daily credits!",
+    argsRequired: false,
+    requirements: {
+        custom: function(msg) {
+            if (!msg.guildID) return false;
+            else if (!CONFIG.SystemConfig.servers[msg.guildID]) return false;
+            else if (!(CONFIG.SystemConfig.servers[msg.guildID].nonstaff.memberaccess.some(id => msg.member.roles.includes(id)))) return false;
+            else return true;
+        }
+    }
+});
+
 STDCreditsCommand.registerSubcommand("port", STD_gamble.credits_port, {
     caseInsensitive: true,
     fullDescription: "Port points to credits.!",

--- a/custom_commands/STD/gamble.js
+++ b/custom_commands/STD/gamble.js
@@ -380,69 +380,77 @@ exports.claim = async function(msg, args) {
     if (!CONFIG.SystemConfig.servers[msg.guildID]) return "You first have to configurate the server. Type \`.instructions\` for help.";
     if (msg.guildID != CONSTANTS.STDGuildID) return;
     
-    MongoClient.connect(process.env.DBURL, {useUnifiedTopology: true, useNewUrlParser: true}, async function(err, db) {
-        if (err) throw (err);
-        var dbo = db.db("GalaxyRaiderDB");
-        let foundEntry = await dbo.collection("GalaxyGambling.UserData").findOne({userID: msg.author.id, guildID: msg.guildID});
-        let object;
-        if (!foundEntry) {
-            object = {
-                guildID: msg.guildID, 
-                userID: msg.author.id,
-                credits: CONSTANTS.defaultCredits + 10,
-                ported: false,
-                wins: 0,
-                losses: 0,
-                winstreak: 0,
-                lastClaim: new Date(),
-                claimStreak: 0,
-            }
+    try {
+        MongoClient.connect(process.env.DBURL, {useUnifiedTopology: true, useNewUrlParser: true}, async function(err, db) {
+            if (err) throw (err);
+            var dbo = db.db("GalaxyRaiderDB");
+            let foundEntry = await dbo.collection("GalaxyGambling.UserData").findOne({userID: msg.author.id, guildID: msg.guildID});
+            let object;
+            if (!foundEntry) {
+                object = {
+                    guildID: msg.guildID, 
+                    userID: msg.author.id,
+                    credits: CONSTANTS.defaultCredits + 10,
+                    ported: false,
+                    wins: 0,
+                    losses: 0,
+                    winstreak: 0,
+                    lastClaim: new Date(),
+                    claimStreak: 0,
+                }
 
-            await dbo.collection("GalaxyGambling.UserData").insertOne(object);
+                await dbo.collection("GalaxyGambling.UserData").insertOne(object);
 
-            msg.channel.createMessage({embed: {description: `Successfully claimed ${toAdd} (+${toAdd - 10} from your streak) daily credits for ${msg.author.mention}`}});
-        } else {
-            if (foundEntry.hasOwnProperty('lastClaim')) {
-                let currDate = new Date();
+                msg.channel.createMessage({embed: {description: `Successfully claimed ${toAdd} (+${toAdd - 10} from your streak) daily credits for ${msg.author.mention}`}});
+            } else {
+                if (foundEntry.hasOwnProperty('lastClaim')) {
+                    let currDate = new Date();
 
-                if (foundEntry.lastClaim.getUTCDate() == currDate.getUTCDate() && foundEntry.lastClaim.getUTCMonth() == currDate.getUTCMonth() && foundEntry.lastClaim.getUTCFullYear() == currDate.getUTCFullYear()) {
-                    msg.channel.createMessage({embed: {description: `You already claimed your credits for today`}});
-                } else {
-                    let streak = 0;
+                    if (foundEntry.lastClaim.getUTCDate() == currDate.getUTCDate() && foundEntry.lastClaim.getUTCMonth() == currDate.getUTCMonth() && foundEntry.lastClaim.getUTCFullYear() == currDate.getUTCFullYear()) {
+                        msg.channel.createMessage({embed: {description: `You already claimed your credits for today`}});
+                    } else {
+                        let streak = 0;
 
-                    if (foundEntry.hasOwnProperty('claimStreak')) {
-                        streak = foundEntry.claimStreak;
+                        if (foundEntry.hasOwnProperty('claimStreak')) {
+                            streak = foundEntry.claimStreak;
 
-                        // Check if the last claim was 'yesterday' to update the streak
-                        let yesterday = new Date();
-                        yesterday.setDate(yesterday.getDate() - 1);
+                            // Check if the last claim was 'yesterday' to update the streak
+                            let yesterday = new Date();
+                            yesterday.setDate(yesterday.getDate() - 1);
 
-                        if (foundEntry.lastClaim.getUTCDate() == yesterday.getUTCDate() && foundEntry.lastClaim.getUTCMonth() == yesterday.getUTCMonth() && foundEntry.lastClaim.getUTCFullYear() == yesterday.getUTCFullYear()) {
-                            streak += 1;
-                        } else {
-                            streak = 0;
+                            if (foundEntry.lastClaim.getUTCDate() == yesterday.getUTCDate() && foundEntry.lastClaim.getUTCMonth() == yesterday.getUTCMonth() && foundEntry.lastClaim.getUTCFullYear() == yesterday.getUTCFullYear()) {
+                                streak += 1;
+                            } else {
+                                streak = 0;
+                            }
                         }
-                    }
-                    
-                    // Add the streak to the base amount, up to +5 for 5 days
-                    let toAdd = streak <= 5 ? 10 + streak : 15;
+                        
+                        // Add the streak to the base amount, up to +5 for 5 days
+                        let toAdd = streak <= 5 ? 10 + streak : 15;
 
-                    // this needs to be two seperate update calls because it didn't work in the one and i don't know why
-                    await dbo.collection("GalaxyGambling.UserData").updateOne({userID: msg.author.id, guildID: msg.guildID}, {$inc: {credits: toAdd}});
-                    await dbo.collection("GalaxyGambling.UserData").updateOne({userID: msg.author.id, guildID: msg.guildID}, {$set: {lastClaim: new Date(), claimStreak: streak}});
+                        // this needs to be two seperate update calls because it didn't work in the one and i don't know why
+                        await dbo.collection("GalaxyGambling.UserData").updateOne({userID: msg.author.id, guildID: msg.guildID}, {$inc: {credits: toAdd}});
+                        await dbo.collection("GalaxyGambling.UserData").updateOne({userID: msg.author.id, guildID: msg.guildID}, {$set: {lastClaim: new Date(), claimStreak: streak}});
+
+                        msg.channel.createMessage({embed: {description: `Successfully claimed ${toAdd} (+${toAdd - 10} from your streak) daily credits for ${msg.author.mention}`}});
+                    }
+                } else {
+                    await dbo.collection("GalaxyGambling.UserData").updateOne({userID: msg.author.id, guildID: msg.guildID}, {$inc: {credits: 10}});
+                    await dbo.collection("GalaxyGambling.UserData").updateOne({userID: msg.author.id, guildID: msg.guildID}, {$set: {lastClaim: new Date(), claimStreak: 0}});
 
                     msg.channel.createMessage({embed: {description: `Successfully claimed ${toAdd} (+${toAdd - 10} from your streak) daily credits for ${msg.author.mention}`}});
                 }
-            } else {
-                await dbo.collection("GalaxyGambling.UserData").updateOne({userID: msg.author.id, guildID: msg.guildID}, {$inc: {credits: 10}});
-                await dbo.collection("GalaxyGambling.UserData").updateOne({userID: msg.author.id, guildID: msg.guildID}, {$set: {lastClaim: new Date(), claimStreak: 0}});
-
-                msg.channel.createMessage({embed: {description: `Successfully claimed ${toAdd} (+${toAdd - 10} from your streak) daily credits for ${msg.author.mention}`}});
             }
-        }
 
-        db.close();
-    })
+            db.close();
+        })
+    } catch (err) {
+        try {
+            await msg.channel.createMessage('Failed to claim your daily credits.')
+        } catch (err) {
+            console.log("[ERROR] ERROR WITH CLAIM COMMAND")
+        }
+    }
 }
 
 exports.credits_port = function(msg, args) {

--- a/custom_commands/STD/gamble.js
+++ b/custom_commands/STD/gamble.js
@@ -349,7 +349,7 @@ exports.credits = function(msg, args) {
                     **Wins**: ${object.wins}
                     **Losses**: ${object.losses}
                     **Win Streak**: ${object.winstreak}
-                    **Claim Streak: 0`,
+                    **Claim Streak**: 0`,
                     color: 3145463
                 }
             })
@@ -401,7 +401,7 @@ exports.claim = async function(msg, args) {
 
                 await dbo.collection("GalaxyGambling.UserData").insertOne(object);
 
-                msg.channel.createMessage({embed: {description: `Successfully claimed ${toAdd} (+${toAdd - 10} from your streak) daily credits for ${msg.author.mention}`}});
+                msg.channel.createMessage({embed: {description: `Successfully claimed 10 (+0 from your streak) daily credits for ${msg.author.mention}`}});
             } else {
                 if (foundEntry.hasOwnProperty('lastClaim')) {
                     let currDate = new Date();
@@ -438,7 +438,7 @@ exports.claim = async function(msg, args) {
                     await dbo.collection("GalaxyGambling.UserData").updateOne({userID: msg.author.id, guildID: msg.guildID}, {$inc: {credits: 10}});
                     await dbo.collection("GalaxyGambling.UserData").updateOne({userID: msg.author.id, guildID: msg.guildID}, {$set: {lastClaim: new Date(), claimStreak: 0}});
 
-                    msg.channel.createMessage({embed: {description: `Successfully claimed ${toAdd} (+${toAdd - 10} from your streak) daily credits for ${msg.author.mention}`}});
+                    msg.channel.createMessage({embed: {description: `Successfully claimed 10 (+0 from your streak) daily credits for ${msg.author.mention}`}});
                 }
             }
 


### PR DESCRIPTION
Hi,

This is the implementation for the daily claim feature. Members should be able to run the `.claim` command once a day to claim 10 daily credits. A claim streak can also be earned by claiming once a day. The amount of credits increases by 1 for each day in the claim streak (up to +5 credits). No changes to the database need to be made as all required fields will be created as needed. I have tested this on my test environment and haven't had any issues.

Thanks 